### PR TITLE
refactor: use buf's remote plugins for go, py and cpp

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,23 +1,53 @@
 version: v1
+
 managed:
   enabled: true
   go_package_prefix:
     default: github.com/cobaltspeech/go-genproto
     except:
       - buf.build/googleapis/googleapis
+
 plugins:
-  - name: go
-    out: gen/go
-    opt: paths=source_relative
-  - name: go-grpc
-    out: gen/go
-    opt: paths=source_relative
-  - name: grpc-gateway
-    out: gen/go/gw
-    opt:
-      - paths=source_relative
-      - standalone=true
+  # Docs
   - name: doc
     out: gen/docs
     opt:
       - ./doc-templates/grpc-md.tmpl,api.md,source_relative
+
+  - plugin: buf.build/grpc-ecosystem/openapiv2
+    out: gen/docs
+
+  #Golang
+  - plugin: buf.build/grpc/go
+    out: gen/go
+    opt: paths=source_relative
+
+  - plugin: buf.build/protocolbuffers/go
+    out: gen/go
+    opt: paths=source_relative
+
+  - plugin: buf.build/grpc-ecosystem/gateway
+    out: gen/go/gw
+    opt:
+      - paths=source_relative
+      - standalone=true
+
+  # Python
+  - plugin: buf.build/grpc/python
+    out: gen/py
+
+  - plugin: buf.build/protocolbuffers/python
+    out: gen/py
+
+  - plugin: buf.build/protocolbuffers/pyi
+    out: gen/py
+
+  # C++
+  - plugin: buf.build/grpc/cpp
+    out: gen/cpp
+
+  - plugin: buf.build/protocolbuffers/cpp
+    out: gen/cpp
+
+  - plugin: buf.build/bufbuild/validate-cpp
+    out: gen/cpp

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668972439,
-        "narHash": "sha256-msePxmSRNi1vHfPCFeSW9u+zkDDouOkW+mH8DjlZaHQ=",
+        "lastModified": 1678693419,
+        "narHash": "sha256-bbSv5yqZAW6dz+3f3f3pOUZbxpPN+3OgCljgn7P+nnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1566922325524035612c13796d7a749fcedc5e1c",
+        "rev": "8e3fad82be64c06fbfb9fd43993aec9ef4623936",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,15 +18,8 @@
             name = "proto";
             buildInputs = with pkgs; [
               buf
-              grpc
-              grpc-gateway
-              pandoc texlive.combined.scheme-small
-              protobuf
               protoc-gen-doc
-              protoc-gen-go
-              protoc-gen-go-grpc
-              go
-              gitFull
+              git
             ];
 
             shellHook = ''


### PR DESCRIPTION
  - Updated buf.gen.yaml to use remote plugins for generating code for go, python and C++.

  - Couldn't get docs remote plugin to work, so still using a locally installed version for that one.

  - Removed deps not required anymore from flake.nix