### PR TITLE
buf: move some sections to cobalt specific file

### DIFF
--- a/bin/generate-and-publish.sh
+++ b/bin/generate-and-publish.sh
@@ -9,7 +9,7 @@ rm -rf gen
 protorev=$(git describe --always)
 
 # generate all code
-buf generate proto
+buf generate --template buf.gen.cobalt.yaml proto
 
 # publish go code
 git clone git@github.com:cobaltspeech/go-genproto

--- a/buf.gen.cobalt.yaml
+++ b/buf.gen.cobalt.yaml
@@ -8,6 +8,15 @@ managed:
       - buf.build/googleapis/googleapis
 
 plugins:
+  # Docs
+  - name: doc
+    out: gen/docs
+    opt:
+      - ./doc-templates/grpc-md.tmpl,api.md,source_relative
+
+  - plugin: buf.build/grpc-ecosystem/openapiv2
+    out: gen/docs
+
   #Golang
   - plugin: buf.build/grpc/go
     out: gen/go
@@ -22,23 +31,3 @@ plugins:
     opt:
       - paths=source_relative
       - standalone=true
-
-  # Python
-  - plugin: buf.build/grpc/python
-    out: gen/py
-
-  - plugin: buf.build/protocolbuffers/python
-    out: gen/py
-
-  - plugin: buf.build/protocolbuffers/pyi
-    out: gen/py
-
-  # C++
-  - plugin: buf.build/grpc/cpp
-    out: gen/cpp
-
-  - plugin: buf.build/protocolbuffers/cpp
-    out: gen/cpp
-
-  - plugin: buf.build/bufbuild/validate-cpp
-    out: gen/cpp

--- a/flake.nix
+++ b/flake.nix
@@ -16,11 +16,7 @@
         shellForPkgs = pkgs:
           pkgs.mkShell {
             name = "proto";
-            buildInputs = with pkgs; [
-              buf
-              protoc-gen-doc
-              git
-            ];
+            buildInputs = with pkgs; [ buf git go protoc-gen-doc ];
 
             shellHook = ''
               export GOPROXY="http://goproxy.in.cobaltspeech.com"


### PR DESCRIPTION
the doc plugin has to run locally and isn't compatible with remote plugins. Therefore moved those to a separate template file for generation, so other users don't need protoc-gen-doc installed in their path.

Also added "go" to the flake buildInputs since the publish code needs it.