### PR TITLE
grpc-gateway: switch to external annotations

### DIFF
--- a/buf.gen.cobalt.yaml
+++ b/buf.gen.cobalt.yaml
@@ -26,10 +26,12 @@ plugins:
     out: gen/go
     opt: paths=source_relative
 
-  - plugin: buf.build/grpc-ecosystem/gateway
+  - plugin: grpc-gateway
     out: gen/go/gw
+    strategy: all
     opt:
       - paths=source_relative
+      - grpc_api_configuration=grpc_gateway_api_config.yaml
       - standalone=true
 
   # Python

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         shellForPkgs = pkgs:
           pkgs.mkShell {
             name = "proto";
-            buildInputs = with pkgs; [ buf git go protoc-gen-doc ];
+            buildInputs = with pkgs; [ buf git go protoc-gen-doc grpc-gateway ];
 
             shellHook = ''
               export GOPROXY="http://goproxy.in.cobaltspeech.com"

--- a/grpc_gateway_api_config.yaml
+++ b/grpc_gateway_api_config.yaml
@@ -1,0 +1,92 @@
+# This file maps rpcs to their http annotations for grpc-gateway
+
+type: google.api.Service
+config_version: 3
+
+http:
+  rules:
+    # bluehenge
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.Version
+      get: /api/bluehenge/v2/version
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.ListModels
+      get: /api/bluehenge/v2/listmodels
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.CreateSession
+      post: /api/bluehenge/v2/createsession
+      body: "*"
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.DeleteSession
+      post: /api/bluehenge/v2/deletesession
+      body: "*"
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.UpdateSession
+      post: /api/bluehenge/v2/updatesession
+      body: "*"
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.ListProcedures
+      get: /api/bluehenge/v2/listprocedures
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.ListTrees
+      get: /api/bluehenge/v2/listtrees
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.ListEntities
+      get: /api/bluehenge/v2/listentities
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetProcedure
+      post: /api/bluehenge/v2/getprocedure
+      body: "*"
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetTask
+      post: /api/bluehenge/v2/gettask
+      body: "*"
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetEntity
+      post: /api/bluehenge/v2/getentity
+      body: "*"
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.SaveNote
+      post: /api/bluehenge/v2/savenote
+      body: "*"
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetExtractionRelationship
+      post: /api/bluehenge/v2/getextractionrelationship
+      body: "*"
+    - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetEntityImageData
+      post: /api/bluehenge/v2/getentityimagedata
+      body: "*"
+
+    # privacyscreen
+    - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.Version
+      get: /api/privacyscreen/v1/version
+    - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.ListModels
+      get: /api/privacyscreen/v1/listmodels
+    - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.RedactText
+      post: /api/privacyscreen/v1/redact_text
+      body: "*"
+    - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.RedactTranscript
+      post: /api/privacyscreen/v1/redact_transcript
+      body: "*"
+    - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.StreamingRedactTranscribedAudio
+      get: /api/privacyscreen/v1/redact_transcribed_audio
+    - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.StreamingTranscribeAndRedact
+      get: /api/privacyscreen/v1/transcribe_and_redact
+
+    # transcribe
+    - selector: cobaltspeech.transcribe.v5.TranscribeService.Version
+      get: /api/transcribe/v5/version
+    - selector: cobaltspeech.transcribe.v5.TranscribeService.ListModels
+      get: /api/transcribe/v5/listmodels
+    - selector: cobaltspeech.transcribe.v5.TranscribeService.StreamingRecognize
+      get: /api/transcribe/v5/stream
+    - selector: cobaltspeech.transcribe.v5.TranscribeService.CompileContext
+      post: /api/transcribe/v5/compilecontext
+      body: "*"
+
+    # voicebio
+    - selector: cobaltspeech.voicebio.v1.VoiceBioService.Version
+      get: /api/voicebio/v1/version
+    - selector: cobaltspeech.voicebio.v1.VoiceBioService.ListModels
+      get: /api/voicebio/v1/listmodels
+    - selector: cobaltspeech.voicebio.v1.VoiceBioService.StreamingEnroll
+      get: /api/voicebio/v1/streaming_enroll
+    - selector: cobaltspeech.voicebio.v1.VoiceBioService.StreamingVerify
+      get: /api/voicebio/v1/streaming_verify
+    - selector: cobaltspeech.voicebio.v1.VoiceBioService.StreamingIdentify
+      get: /api/voicebio/v1/streaming_identify
+
+    # voicegen
+    - selector: cobaltspeech.voicegen.v1.VoiceGenService.Version
+      get: /api/voicegen/v1/version
+    - selector: cobaltspeech.voicegen.v1.VoiceGenService.ListModels
+      get: /api/voicegen/v1/listmodels
+    - selector: cobaltspeech.voicegen.v1.VoiceGenService.StreamingSynthesize
+      get: /api/voicegen/v1/synthesize

--- a/grpc_gateway_api_config.yaml
+++ b/grpc_gateway_api_config.yaml
@@ -9,84 +9,84 @@ http:
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.Version
       get: /api/bluehenge/v2/version
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.ListModels
-      get: /api/bluehenge/v2/listmodels
+      get: /api/bluehenge/v2/list-models
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.CreateSession
-      post: /api/bluehenge/v2/createsession
+      post: /api/bluehenge/v2/create-session
       body: "*"
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.DeleteSession
-      post: /api/bluehenge/v2/deletesession
+      post: /api/bluehenge/v2/delete-session
       body: "*"
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.UpdateSession
-      post: /api/bluehenge/v2/updatesession
+      post: /api/bluehenge/v2/update-session
       body: "*"
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.ListProcedures
-      get: /api/bluehenge/v2/listprocedures
+      get: /api/bluehenge/v2/list-procedures
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.ListTrees
-      get: /api/bluehenge/v2/listtrees
+      get: /api/bluehenge/v2/list-trees
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.ListEntities
-      get: /api/bluehenge/v2/listentities
+      get: /api/bluehenge/v2/list-entities
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetProcedure
-      post: /api/bluehenge/v2/getprocedure
+      post: /api/bluehenge/v2/get-procedure
       body: "*"
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetTask
-      post: /api/bluehenge/v2/gettask
+      post: /api/bluehenge/v2/get-task
       body: "*"
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetEntity
-      post: /api/bluehenge/v2/getentity
+      post: /api/bluehenge/v2/get-entity
       body: "*"
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.SaveNote
-      post: /api/bluehenge/v2/savenote
+      post: /api/bluehenge/v2/save-note
       body: "*"
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetExtractionRelationship
-      post: /api/bluehenge/v2/getextractionrelationship
+      post: /api/bluehenge/v2/get-extraction-relationship
       body: "*"
     - selector: cobaltspeech.bluehenge.v2.BluehengeService.GetEntityImageData
-      post: /api/bluehenge/v2/getentityimagedata
+      post: /api/bluehenge/v2/get-entity-image-data
       body: "*"
 
     # privacyscreen
     - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.Version
       get: /api/privacyscreen/v1/version
     - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.ListModels
-      get: /api/privacyscreen/v1/listmodels
+      get: /api/privacyscreen/v1/list-models
     - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.RedactText
-      post: /api/privacyscreen/v1/redact_text
+      post: /api/privacyscreen/v1/redact-text
       body: "*"
     - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.RedactTranscript
-      post: /api/privacyscreen/v1/redact_transcript
+      post: /api/privacyscreen/v1/redact-transcript
       body: "*"
     - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.StreamingRedactTranscribedAudio
-      get: /api/privacyscreen/v1/redact_transcribed_audio
+      get: /api/privacyscreen/v1/streaming-redact-transcribed-audio
     - selector: cobaltspeech.privacyscreen.v1.PrivacyScreenService.StreamingTranscribeAndRedact
-      get: /api/privacyscreen/v1/transcribe_and_redact
+      get: /api/privacyscreen/v1/streaming-transcribe-and-redact
 
     # transcribe
     - selector: cobaltspeech.transcribe.v5.TranscribeService.Version
       get: /api/transcribe/v5/version
     - selector: cobaltspeech.transcribe.v5.TranscribeService.ListModels
-      get: /api/transcribe/v5/listmodels
+      get: /api/transcribe/v5/list-models
     - selector: cobaltspeech.transcribe.v5.TranscribeService.StreamingRecognize
-      get: /api/transcribe/v5/stream
+      get: /api/transcribe/v5/streaming-recognize
     - selector: cobaltspeech.transcribe.v5.TranscribeService.CompileContext
-      post: /api/transcribe/v5/compilecontext
+      post: /api/transcribe/v5/compile-context
       body: "*"
 
     # voicebio
     - selector: cobaltspeech.voicebio.v1.VoiceBioService.Version
       get: /api/voicebio/v1/version
     - selector: cobaltspeech.voicebio.v1.VoiceBioService.ListModels
-      get: /api/voicebio/v1/listmodels
+      get: /api/voicebio/v1/list-models
     - selector: cobaltspeech.voicebio.v1.VoiceBioService.StreamingEnroll
-      get: /api/voicebio/v1/streaming_enroll
+      get: /api/voicebio/v1/streaming-enroll
     - selector: cobaltspeech.voicebio.v1.VoiceBioService.StreamingVerify
-      get: /api/voicebio/v1/streaming_verify
+      get: /api/voicebio/v1/streaming-verify
     - selector: cobaltspeech.voicebio.v1.VoiceBioService.StreamingIdentify
-      get: /api/voicebio/v1/streaming_identify
+      get: /api/voicebio/v1/streaming-identify
 
     # voicegen
     - selector: cobaltspeech.voicegen.v1.VoiceGenService.Version
       get: /api/voicegen/v1/version
     - selector: cobaltspeech.voicegen.v1.VoiceGenService.ListModels
-      get: /api/voicegen/v1/listmodels
+      get: /api/voicegen/v1/list-models
     - selector: cobaltspeech.voicegen.v1.VoiceGenService.StreamingSynthesize
-      get: /api/voicegen/v1/synthesize
+      get: /api/voicegen/v1/streaming-synthesize

--- a/proto/cobaltspeech/bluehenge/v2/bluehenge.proto
+++ b/proto/cobaltspeech/bluehenge/v2/bluehenge.proto
@@ -15,7 +15,6 @@ syntax = "proto3";
 package cobaltspeech.bluehenge.v2;
 
 import "cobaltspeech/diatheke/v3/diatheke.proto";
-import "google/api/annotations.proto";
 
 // Bluehenge is designed to help with maintainance and repair tasks.
 // When paired with other cobalt offerings, it can provide a hands-free virtual assistant for technicians.
@@ -41,43 +40,24 @@ import "google/api/annotations.proto";
 
 service BluehengeService {
   // Returns version information of the Bluehenge server.
-  rpc Version(VersionRequest) returns (VersionResponse) {
-    option (google.api.http) = {get: "/api/v2/version"};
-  }
+  rpc Version(VersionRequest) returns (VersionResponse) {}
 
   // ListModels returns information about the Bluehenge models
   // the server can access.
-  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
-    option (google.api.http) = {get: "/api/v2/listmodels"};
-  }
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {}
 
   // Create a new Bluehenge session. Also returns a list of
   // actions to take next.
-  rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/createsession"
-      body: "*"
-    };
-  }
+  rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse) {}
 
   // Delete the session. Behavior is undefined if the given
   // TokenData is used again after this function is called.
-  rpc DeleteSession(DeleteSessionRequest) returns (DeleteSessionResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/deletesession"
-      body: "*"
-    };
-  }
+  rpc DeleteSession(DeleteSessionRequest) returns (DeleteSessionResponse) {}
 
   // Process input for a session and get an updated session with
   // a list of actions to take next. This is the only method
   // that modifies the Bluehenge session state.
-  rpc UpdateSession(UpdateSessionRequest) returns (UpdateSessionResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/updatesession"
-      body: "*"
-    };
-  }
+  rpc UpdateSession(UpdateSessionRequest) returns (UpdateSessionResponse) {}
 
   // Create an ASR stream. A result is returned when the
   // stream is closed by the client (which forces the ASR to
@@ -118,43 +98,30 @@ service BluehengeService {
   // Returns a list of all the procedures.
   // This list is contains a simplified representation of the procedures,
   // which can be helpful for displaying a directory or table of contents.
-  // The full details of an individual procedure can be retrieved via GetProcedure.
-  rpc ListProcedures(ListProceduresRequest) returns (ListProceduresResponse) {
-    option (google.api.http) = {get: "/api/v2/listprocedures"};
-  }
+  // The full details of an individual procedure can be retrieved via
+  // GetProcedure.
+  rpc ListProcedures(ListProceduresRequest) returns (ListProceduresResponse) {}
 
   // Returns a list of all the trees.
   // This list is contains a simplified representation of the trees,
   // which can be helpful for displaying a directory or table of contents.
   // The full details of an individual tree can be retrieved via GetTree.
-  rpc ListTrees(ListTreesRequest) returns (ListTreesResponse) {
-    option (google.api.http) = {get: "/api/v2/listtrees"};
-  }
+  rpc ListTrees(ListTreesRequest) returns (ListTreesResponse) {}
 
   // Returns a list of all entities.
   // This list contains every entity in the knowledge graph and can
   // be used for fuzzy matching or any other time you need everything.
-  rpc ListEntities(ListEntitiesRequest) returns (ListEntitiesResponse) {
-    option (google.api.http) = {get: "/api/v2/listentities"};
-  }
+  rpc ListEntities(ListEntitiesRequest) returns (ListEntitiesResponse) {}
 
   // Gets a single procedure identified by id.
-  // The response returns everything you should need to be able to display the Procedure and it's Steps and Tasks to the user.
-  rpc GetProcedure(GetProcedureRequest) returns (GetProcedureResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/getprocedure"
-      body: "*"
-    };
-  }
+  // The response returns everything you should need to be able to display the
+  // Procedure and it's Steps and Tasks to the user.
+  rpc GetProcedure(GetProcedureRequest) returns (GetProcedureResponse) {}
 
   // Gets a single task identified by id.
-  // The response returns everything you should need to be able to display the Task and it's Steps to the user.
-  rpc GetTask(GetTaskRequest) returns (GetTaskResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/gettask"
-      body: "*"
-    };
-  }
+  // The response returns everything you should need to be able to display the
+  // Task and it's Steps to the user.
+  rpc GetTask(GetTaskRequest) returns (GetTaskResponse) {}
 
   // Gets a single tree identified by id.
   // Trees contain instructions followed by questions to help users
@@ -162,50 +129,25 @@ service BluehengeService {
   // TreeNode to continue the diagnosis. This response returns an
   // information bearing Tree struct with a list of its TreeNodes in
   // a linear order starting with the first one the user should see.
-  rpc GetTree(GetTreeRequest) returns (GetTreeResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/gettree"
-      body: "*"
-    };
-  }
+  rpc GetTree(GetTreeRequest) returns (GetTreeResponse) {}
 
   // Saves a note in a specific step during a procedure.
-  rpc SaveNote(SaveNoteRequest) returns (SaveNoteResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/savenote",
-      body: "*"
-    };
-  }
+  rpc SaveNote(SaveNoteRequest) returns (SaveNoteResponse) {}
 
   // Gets the data related with an entity extraction triple for a
   // specific entity-relation pair, e.g. entity:"sky", relation:"has color"
   // Extractions contain Subject-Relation-Object sets. For example,
   // entity:"sky", relation:"has color", object:"blue".
-  rpc GetExtractionRelationship(GetExtractionRelationshipRequest) returns (GetExtractionRelationshipResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/getextractionrelationship"
-      body: "*"
-    };
-  }
+  rpc GetExtractionRelationship(GetExtractionRelationshipRequest) returns (GetExtractionRelationshipResponse) {}
 
   // Gets the data contained within a single entity identified by name.
   // Entities contain information about parts and other question
   // answering content. See Entity for more details.
-  rpc GetEntity(GetEntityRequest) returns (GetEntityResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/getentity"
-      body: "*"
-    };
-  }
+  rpc GetEntity(GetEntityRequest) returns (GetEntityResponse) {}
 
   // Gets the data related with an image.
   // The actual image will be served over HTTP.
-  rpc GetEntityImageData(GetEntityImageDataRequest) returns (GetEntityImageDataResponse) {
-    option (google.api.http) = {
-      post: "/api/v2/getentityimage"
-      body: "*"
-    };
-  }
+  rpc GetEntityImageData(GetEntityImageDataRequest) returns (GetEntityImageDataResponse) {}
 }
 
 // Empty request for Bluehenge Version

--- a/proto/cobaltspeech/cubic/v1/cubic.proto
+++ b/proto/cobaltspeech/cubic/v1/cubic.proto
@@ -16,39 +16,27 @@ syntax = "proto3";
 
 package cobaltspeech.cubic;
 
-import "google/api/annotations.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 
 // Service that implements the Cobalt Cubic Speech Recognition API
 service Cubic {
   // Queries the Version of the Server
-  rpc Version(google.protobuf.Empty) returns (VersionResponse) {
-    option (google.api.http) = {get: "/api/version"};
-  }
+  rpc Version(google.protobuf.Empty) returns (VersionResponse) {}
 
   // Retrieves a list of available speech recognition models
-  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
-    option (google.api.http) = {get: "/api/listmodels"};
-  }
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {}
 
   // Performs synchronous speech recognition: receive results after all audio
   // has been sent and processed.  It is expected that this request be typically
   // used for short audio content: less than a minute long.  For longer content,
   // the `StreamingRecognize` method should be preferred.
-  rpc Recognize(RecognizeRequest) returns (RecognitionResponse) {
-    option (google.api.http) = {
-      post: "/api/recognize"
-      body: "*"
-    };
-  }
+  rpc Recognize(RecognizeRequest) returns (RecognitionResponse) {}
 
   // Performs bidirectional streaming speech recognition.  Receive results while
   // sending audio.  This method is only available via GRPC and not via
   // HTTP+JSON. However, a web browser may use websockets to use this service.
-  rpc StreamingRecognize(stream StreamingRecognizeRequest) returns (stream RecognitionResponse) {
-    option (google.api.http) = {get: "/api/stream"};
-  }
+  rpc StreamingRecognize(stream StreamingRecognizeRequest) returns (stream RecognitionResponse) {}
 
   // Compiles recognition context information, such as a specialized list of
   // words or phrases, into a compact, efficient form to send with subsequent
@@ -63,12 +51,7 @@ service Cubic {
   // `ListModels` method. Also, the compiled data will be model specific; that
   // is, the data compiled for one model will generally not be usable with a
   // different model.
-  rpc CompileContext(CompileContextRequest) returns (CompileContextResponse) {
-    option (google.api.http) = {
-      post: "/api/compilecontext"
-      body: "*"
-    };
-  }
+  rpc CompileContext(CompileContextRequest) returns (CompileContextResponse) {}
 }
 
 // The top-level message sent by the client for the `ListModels` method.

--- a/proto/cobaltspeech/cubic/v5/cubic.proto
+++ b/proto/cobaltspeech/cubic/v5/cubic.proto
@@ -19,26 +19,18 @@ syntax = "proto3";
 
 package cobaltspeech.cubic.v5;
 
-import "google/api/annotations.proto";
-
 // Service that implements the Cobalt Cubic Speech Recognition API.
 service CubicService {
   // Queries the version of the server.
-  rpc Version(VersionRequest) returns (VersionResponse) {
-    option (google.api.http) = {get: "/api/v5/version"};
-  }
+  rpc Version(VersionRequest) returns (VersionResponse) {}
 
   // Retrieves a list of available speech recognition models.
-  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
-    option (google.api.http) = {get: "/api/v5/listmodels"};
-  }
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse);
 
   // Performs bidirectional streaming speech recognition. Receive results while
   // sending audio. This method is only available via GRPC and not via
   // HTTP+JSON. However, a web browser may use websockets to use this service.
-  rpc StreamingRecognize(stream StreamingRecognizeRequest) returns (stream StreamingRecognizeResponse) {
-    option (google.api.http) = {get: "/api/v5/stream"};
-  }
+  rpc StreamingRecognize(stream StreamingRecognizeRequest) returns (stream StreamingRecognizeResponse) {}
 
   // Compiles recognition context information, such as a specialized list of
   // words or phrases, into a compact, efficient form to send with subsequent
@@ -52,12 +44,7 @@ service CubicService {
   // `ModelAttributes.ContextInfo` obtained via the `ListModels` method. Also,
   // the compiled data will be model specific; that is, the data compiled for
   // one model will generally not be usable with a different model.
-  rpc CompileContext(CompileContextRequest) returns (CompileContextResponse) {
-    option (google.api.http) = {
-      post: "/api/v5/compilecontext"
-      body: "*"
-    };
-  }
+  rpc CompileContext(CompileContextRequest) returns (CompileContextResponse) {}
 }
 
 // The top-level message sent by the client for the `Version` method.

--- a/proto/cobaltspeech/privacyscreen/v1/privacyscreen.proto
+++ b/proto/cobaltspeech/privacyscreen/v1/privacyscreen.proto
@@ -16,50 +16,30 @@ syntax = "proto3";
 
 package cobaltspeech.privacyscreen.v1;
 
-import "google/api/annotations.proto";
-
 // Service that implements the Cobalt Privacy Screen API.
 service PrivacyScreenService {
   // Returns version information from the server.
-  rpc Version(VersionRequest) returns (VersionResponse) {
-    option (google.api.http) = {get: "/api/v1/version"};
-  }
+  rpc Version(VersionRequest) returns (VersionResponse) {}
 
   // ListModels returns information about the models the server can access.
-  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
-    option (google.api.http) = {get: "/api/v1/listmodels"};
-  }
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {}
 
   // Redact text using a redaction engine that is configured with the provided
   // redaction configuration.
-  rpc RedactText(RedactTextRequest) returns (RedactTextResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/redact_text"
-      body: "*"
-    };
-  }
+  rpc RedactText(RedactTextRequest) returns (RedactTextResponse) {}
 
   // redacts transcript using a redaction engine that is configured with the
   // provided redaction configuration.
-  rpc RedactTranscript(RedactTranscriptRequest) returns (RedactTranscriptResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/redact_transcript"
-      body: "*"
-    };
-  }
+  rpc RedactTranscript(RedactTranscriptRequest) returns (RedactTranscriptResponse) {}
 
   // Performs bidirectional streaming redaction on transcribed audio. Receive
   // redacted audio while sending audio. The transcription of audio data must be
   // ready before sending the audio.
-  rpc StreamingRedactTranscribedAudio(stream StreamingRedactTranscribedAudioRequest) returns (stream StreamingRedactTranscribedAudioResponse) {
-    option (google.api.http) = {get: "/api/v1/redact_transcribed_audio"};
-  }
+  rpc StreamingRedactTranscribedAudio(stream StreamingRedactTranscribedAudioRequest) returns (stream StreamingRedactTranscribedAudioResponse) {}
 
   // Performs bidirectional streaming speech recognition and redaction. Receive
   // redacted audio and transcriptions while sending audio.
-  rpc StreamingTranscribeAndRedact(stream StreamingTranscribeAndRedactRequest) returns (stream StreamingTranscribeAndRedactResponse) {
-    option (google.api.http) = {get: "/api/v1/transcribed_and_redact"};
-  }
+  rpc StreamingTranscribeAndRedact(stream StreamingTranscribeAndRedactRequest) returns (stream StreamingTranscribeAndRedactResponse) {}
 }
 
 // The top-level message sent by the client for the `Version` method.

--- a/proto/cobaltspeech/transcribe/v5/transcribe.proto
+++ b/proto/cobaltspeech/transcribe/v5/transcribe.proto
@@ -19,26 +19,18 @@ syntax = "proto3";
 
 package cobaltspeech.transcribe.v5;
 
-import "google/api/annotations.proto";
-
 // Service that implements the Cobalt Transcribe Speech Recognition API.
 service TranscribeService {
   // Queries the version of the server.
-  rpc Version(VersionRequest) returns (VersionResponse) {
-    option (google.api.http) = {get: "/api/transcribe/v5/version"};
-  }
+  rpc Version(VersionRequest) returns (VersionResponse) {}
 
   // Retrieves a list of available speech recognition models.
-  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
-    option (google.api.http) = {get: "/api/transcribe/v5/listmodels"};
-  }
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {}
 
   // Performs bidirectional streaming speech recognition. Receive results while
   // sending audio. This method is only available via GRPC and not via
   // HTTP+JSON. However, a web browser may use websockets to use this service.
-  rpc StreamingRecognize(stream StreamingRecognizeRequest) returns (stream StreamingRecognizeResponse) {
-    option (google.api.http) = {get: "/api/transcribe/v5/stream"};
-  }
+  rpc StreamingRecognize(stream StreamingRecognizeRequest) returns (stream StreamingRecognizeResponse) {}
 
   // Compiles recognition context information, such as a specialized list of
   // words or phrases, into a compact, efficient form to send with subsequent
@@ -52,12 +44,7 @@ service TranscribeService {
   // `ModelAttributes.ContextInfo` obtained via the `ListModels` method. Also,
   // the compiled data will be model specific; that is, the data compiled for
   // one model will generally not be usable with a different model.
-  rpc CompileContext(CompileContextRequest) returns (CompileContextResponse) {
-    option (google.api.http) = {
-      post: "/api/transcribe/v5/compilecontext"
-      body: "*"
-    };
-  }
+  rpc CompileContext(CompileContextRequest) returns (CompileContextResponse) {}
 }
 
 // The top-level message sent by the client for the `Version` method.

--- a/proto/cobaltspeech/voicebio/v1/voicebio.proto
+++ b/proto/cobaltspeech/voicebio/v1/voicebio.proto
@@ -16,19 +16,13 @@ syntax = "proto3";
 
 package cobaltspeech.voicebio.v1;
 
-import "google/api/annotations.proto";
-
 // Service that implements the Cobalt VoiceBio API.
 service VoiceBioService {
   // Returns version information from the server.
-  rpc Version(VersionRequest) returns (VersionResponse) {
-    option (google.api.http) = {get: "/api/v1/version"};
-  }
+  rpc Version(VersionRequest) returns (VersionResponse) {}
 
   // Returns information about the models available on the server.
-  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
-    option (google.api.http) = {get: "/api/v1/listmodels"};
-  }
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {}
 
   // Uses new audio data to perform enrollment of new users, or to update
   // enrollment of existing users. Returns a new or updated voiceprint.
@@ -40,21 +34,15 @@ service VoiceBioService {
   // If this call is used to update an existing user's voiceprint, the old
   // voiceprint can be discarded and only the new one can be stored for that
   // user.
-  rpc StreamingEnroll(stream StreamingEnrollRequest) returns (StreamingEnrollResponse) {
-    option (google.api.http) = {get: "/api/v1/streaming_enroll"};
-  }
+  rpc StreamingEnroll(stream StreamingEnrollRequest) returns (StreamingEnrollResponse) {}
 
   // Compares audio data against the provided voiceprint and verifies whether or
   // not the audio matches against the voiceprint.
-  rpc StreamingVerify(stream StreamingVerifyRequest) returns (StreamingVerifyResponse) {
-    option (google.api.http) = {get: "/api/v1/streaming_verify"};
-  }
+  rpc StreamingVerify(stream StreamingVerifyRequest) returns (StreamingVerifyResponse) {}
 
   // Compares audio data against the provided list of voiceprints and identifies
   // which (or none) of the voiceprints is a match for the given audio.
-  rpc StreamingIdentify(stream StreamingIdentifyRequest) returns (StreamingIdentifyResponse) {
-    option (google.api.http) = {get: "/api/v1/streaming_identify"};
-  }
+  rpc StreamingIdentify(stream StreamingIdentifyRequest) returns (StreamingIdentifyResponse) {}
 }
 
 // The top-level message sent by the client for the `Version` method.

--- a/proto/cobaltspeech/voicegen/v1/voicegen.proto
+++ b/proto/cobaltspeech/voicegen/v1/voicegen.proto
@@ -16,26 +16,18 @@ syntax = "proto3";
 
 package cobaltspeech.voicegen.v1;
 
-import "google/api/annotations.proto";
-
 // Service that implements the Cobalt VoiceGen API.
 service VoiceGenService {
   // Returns version information from the server.
-  rpc Version(VersionRequest) returns (VersionResponse) {
-    option (google.api.http) = {get: "/api/v1/version"};
-  }
+  rpc Version(VersionRequest) returns (VersionResponse) {}
 
   // ListModels returns information about the models the server can access.
-  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {
-    option (google.api.http) = {get: "/api/v1/listmodels"};
-  }
+  rpc ListModels(ListModelsRequest) returns (ListModelsResponse) {}
 
   // Performs text to speech synthesis and stream synthesized audio. This
   // method is only available via GRPC and not via HTTP+JSON. However, a
   // web browser may use websockets to use this service.
-  rpc StreamingSynthesize(StreamingSynthesizeRequest) returns (stream StreamingSynthesizeResponse) {
-    option (google.api.http) = {get: "/api/v1/synthesize"};
-  }
+  rpc StreamingSynthesize(StreamingSynthesizeRequest) returns (stream StreamingSynthesizeResponse) {}
 }
 
 // The top-level message sent by the client for the `Version` method.


### PR DESCRIPTION
Cobalt uses grpc-gateway in the servers to provide a http gateway to grpc services. Previously, the mapping of services to http paths was added as annotations in the proto files. However, this imposes a dependency on "google/api/annotations.proto". Client implementations don't need the gateway code and the dependency on annotations.proto is thus unnecessary.

This commit switches the api mapping from in-proto annotations to an external config file that grpc-gateway uses for code generation.