### PR TITLE
feat(diatheke,interact): add reply_id to ReplyAction

### DIFF
--- a/proto/cobaltspeech/diatheke/v3/diatheke.proto
+++ b/proto/cobaltspeech/diatheke/v3/diatheke.proto
@@ -337,6 +337,10 @@ message ReplyAction {
 
   // TTS model to use with the TTSReply method
   string luna_model = 2;
+
+  // ID of the reply (or slot prompt) definition in the Diatheke model that
+  // produced this text.
+  string reply_id = 3;
 }
 
 // This action indicates that the client application should

--- a/proto/cobaltspeech/interact/v3/interact.proto
+++ b/proto/cobaltspeech/interact/v3/interact.proto
@@ -334,6 +334,10 @@ message ReplyAction {
 
   // TTS model to use with the TTSReply method
   string luna_model = 2;
+
+  // ID of the reply (or slot prompt) definition in the Diatheke model that
+  // produced this text.
+  string reply_id = 3;
 }
 
 // This action indicates that the client application should


### PR DESCRIPTION
Add a reply_id field (field 3) to the ReplyAction message in both the diatheke/v3 and interact/v3 APIs. It carries the ID of the reply (or slot prompt) definition in the Diatheke model that produced the reply text, so clients can correlate a spoken/displayed reply with its model definition.

Additive, backwards-compatible (new optional field).