### PR TITLE
chosun/v2: add expected_entities to ParseRequest

### DIFF
--- a/proto/cobaltspeech/chosun/v2/chosun.proto
+++ b/proto/cobaltspeech/chosun/v2/chosun.proto
@@ -104,7 +104,8 @@ message ParseRequest {
 
   // Entities the caller expects for this query (for example, the slot being
   // filled during slot filling). A slot-fill-aware extractor uses this to tag
-  // a bare answer as the expected slot. If the list is empty, no expectation
+  // a bare answer as the expected slot. These are entity *names*, not values,
+  // and their order is not significant. If the list is empty, no expectation
   // is supplied.
   repeated string expected_entities = 9;
 }

--- a/proto/cobaltspeech/chosun/v2/chosun.proto
+++ b/proto/cobaltspeech/chosun/v2/chosun.proto
@@ -101,6 +101,12 @@ message ParseRequest {
   // List of whitelisted intents. If the list is empty, all intents will be
   // considered.
   repeated string intent_whitelist = 8;
+
+  // Entities the caller expects for this query (for example, the slot being
+  // filled during slot filling). A slot-fill-aware extractor uses this to tag
+  // a bare answer as the expected slot. If the list is empty, no expectation
+  // is supplied.
+  repeated string expected_entities = 9;
 }
 
 message NBest {


### PR DESCRIPTION
## chosun/v2: add `expected_entities` to `ParseRequest`

Adds a `repeated string expected_entities = 9` field to the chosun `ParseRequest` so a caller can tell the NLU which entities it expects for a query — e.g. the slot being filled during slot filling. A slot-fill-aware entity extractor uses this to tag a bare answer as the expected slot (e.g. "50" → `wattage` rather than another numeric slot). Empty = no expectation.

This carries the slot-fill context over the **gRPC** NLU path; the in-process/embedded path already carries it via the Go API. Pairs with:
- cobaltspeech/chosun#254 (the `slotfill_entity_extractor` + `ExpectedEntities` plumbing)
- cobaltspeech/diatheke#644 (sends the expected slot from the story)

Backward compatible (additive field). Next: regenerate go-genproto, then wire `expected_entities` through chosun's and diatheke's apiconv `ParseRequest`⇄proto converters.
