### PR TITLE
proto: correct ListModelsResponse field comments

### DIFF
--- a/proto/cobaltspeech/cubic/v1/cubic.proto
+++ b/proto/cobaltspeech/cubic/v1/cubic.proto
@@ -117,7 +117,7 @@ message VersionResponse {
 
 // The message returned to the client by the `ListModels` method.
 message ListModelsResponse {
-  // List of models available for use that match the request.
+  // List of models available for use.
   repeated Model models = 1;
 }
 

--- a/proto/cobaltspeech/cubic/v5/cubic.proto
+++ b/proto/cobaltspeech/cubic/v5/cubic.proto
@@ -61,7 +61,7 @@ message ListModelsRequest {}
 
 // The message returned to the client by the `ListModels` method.
 message ListModelsResponse {
-  // List of models available for use that match the request.
+  // List of models available for use.
   repeated Model models = 1;
 }
 

--- a/proto/cobaltspeech/transcribe/v5/transcribe.proto
+++ b/proto/cobaltspeech/transcribe/v5/transcribe.proto
@@ -61,7 +61,7 @@ message ListModelsRequest {}
 
 // The message returned to the client by the `ListModels` method.
 message ListModelsResponse {
-  // List of models available for use that match the request.
+  // List of models available for use.
   repeated Model models = 1;
 }
 

--- a/proto/cobaltspeech/voicebio/v1/voicebio.proto
+++ b/proto/cobaltspeech/voicebio/v1/voicebio.proto
@@ -82,7 +82,7 @@ message ListModelsRequest {}
 
 // The message returned to the client by the `ListModels` method.
 message ListModelsResponse {
-  // List of models available for use that match the request.
+  // List of models available for use.
   repeated Model models = 1;
 }
 

--- a/proto/cobaltspeech/voicegen/v1/voicegen.proto
+++ b/proto/cobaltspeech/voicegen/v1/voicegen.proto
@@ -44,7 +44,7 @@ message ListModelsRequest {}
 
 // The message returned to the client by the `ListModels` method.
 message ListModelsResponse {
-  // List of models available for use on Privacy Screen server.
+  // List of models available for use that match the request.
   repeated ModelInfo models = 1;
 }
 

--- a/proto/cobaltspeech/voicegen/v1/voicegen.proto
+++ b/proto/cobaltspeech/voicegen/v1/voicegen.proto
@@ -44,7 +44,7 @@ message ListModelsRequest {}
 
 // The message returned to the client by the `ListModels` method.
 message ListModelsResponse {
-  // List of models available for use that match the request.
+  // List of models available for use.
   repeated ModelInfo models = 1;
 }
 


### PR DESCRIPTION
Two comment-only commits on `ListModelsResponse.models`.

## 1. voicegen referred to the wrong product

The comment in `voicegen/v1/voicegen.proto` named Privacy Screen:

```protobuf
// List of models available for use on Privacy Screen server.
repeated ModelInfo models = 1;
```

A copy-paste artifact — this is the VoiceGen service.

## 2. Dropped a phrase that described nothing

The wording the other services used was itself inaccurate:

```
-  // List of models available for use that match the request.
+  // List of models available for use.
```

`ListModelsRequest` is `{}` in every one of these services, so "that match the
request" described a filter no caller can express. Rather than copy that phrase
into voicegen, this removes it, settling five files on one accurate sentence:
`cubic/v1`, `cubic/v5`, `transcribe/v5`, `voicebio/v1` and `voicegen/v1`.

## Scope and verification

- No `that match the request` remains anywhere under `proto/`.
- `Privacy Screen` now appears only in `privacyscreen/v1`, where it is correct.
- `privacyscreen/v1` keeps its own wording, "List of models available for use on
  Privacy Screen server", deliberately: it is accurate there.
- Of the eleven `ListModelsResponse` messages in the repository, five are
  covered here, one is `privacyscreen/v1` above, and the remaining five
  (`bluehenge/v1`, `bluehenge/v2`, `chosun/v2`, `diatheke/v3`, `interact/v3`)
  have no comment on the field at all. Adding comments where none exist is a
  different change and is left out.

Comment-only: no field numbers, names, types or service definitions change, so
there is no wire-format or generated-API impact and `breaking-check` passes. The
text does reach generated doc strings, so the next publish will carry a
comment-only diff downstream.
