### PR TITLE
ci: report on the pull request found at the start of a run

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
-      stuck_pr: ${{ steps.unresolved.outputs.number }}
+      stuck_pr: ${{ steps.existing_pr.outputs.number }}
     env:
       APPROVER_CLIENT_ID: ${{ secrets.PROTO_APPROVER_APP_CLIENT_ID }}
 
@@ -137,22 +137,8 @@ jobs:
             || GH_TOKEN="${PUBLISHER_TOKEN}" \
               gh pr merge bot/flake-update --rebase
 
-      # Only an earlier run's pull request that this one did not resolve is
-      # worth reporting.
-      - name: check earlier pull request
-        id: unresolved
-        if: steps.existing_pr.outputs.number != ''
-        env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          NUMBER: ${{ steps.existing_pr.outputs.number }}
-        run: |
-          state=$(gh pr view "${NUMBER}" --json state --jq .state)
-          echo "PR #${NUMBER} is ${state}"
-          if [[ "${state}" == "OPEN" ]]; then
-            echo "number=${NUMBER}" >> "$GITHUB_OUTPUT"
-          fi
-
-  # Report a pull request left open by an earlier run.
+  # A pull request left over from a previous run means that run did not
+  # land it.
   notify-stuck-pr:
     needs: update
     if: needs.update.outputs.stuck_pr != ''
@@ -172,12 +158,12 @@ jobs:
               - type: header
                 text:
                   type: plain_text
-                  text: '⏳ Flake update did not merge'
+                  text: '⏳ Flake-update PR needs attention'
                   emoji: true
               - type: section
                 text:
                   type: mrkdwn
-                  text: '`${{ github.repository }}` PR #${{ needs.update.outputs.stuck_pr }} (`bot/flake-update`) was open before this run and still is.'
+                  text: '`${{ github.repository }}` PR #${{ needs.update.outputs.stuck_pr }} (`bot/flake-update`) is open from a previous run and has not auto-merged.'
               - type: actions
                 elements:
                   - type: button


### PR DESCRIPTION
The first run that merged the flake update also reported the pull request as
outstanding, thirty-seven seconds before it merged. Auto-merge waits for the
checks, which the run itself restarts when it pushes, so asking whether the
pull request is still open at the end of the run races the merge.

A pull request that is already open when a run starts is the signal on its own:
the run before it should have landed one. So this drops the end-of-run question
and reports on the start-of-run detection, which is what the shared workflow in
`cobaltspeech/.github` does. The wording now matches it too.

Net effect is a deletion — one step and its output plumbing.

CORE-2317
